### PR TITLE
Fixed a bug with the slug creation

### DIFF
--- a/django_admin_index/__init__.py
+++ b/django_admin_index/__init__.py
@@ -10,7 +10,7 @@ import re
 
 from collections import namedtuple
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __author__ = 'Joeri Bekker'
 __contact__ = 'joeri@maykinmedia.nl'
 __homepage__ = 'https://github.com/maykinmedia/django-admin-index'

--- a/django_admin_index/models.py
+++ b/django_admin_index/models.py
@@ -70,7 +70,7 @@ class AppGroupQuerySet(models.QuerySet):
             for model in other:
                 names = model.split('.')
                 app_group, created = AppGroup.objects.get_or_create(
-                    slug=names[0], name=names[0].title())
+                    slug=names[0], defaults={'name': names[0].title()})
                 contenttype = ContentTypeProxy.objects.get(
                     app_label=names[0], model=names[1])
                 app_group.models.add(contenttype)

--- a/tests/unit/test_app_group.py
+++ b/tests/unit/test_app_group.py
@@ -137,6 +137,18 @@ class AdminIndexAppGroupTests(TestCase):
             self.assertEqual(app_model[key], original_app[key])
         settings.AUTO_CREATE_APP_GROUP = False
 
+    def test_only_match_auto_create_group_on_slug(self):
+        settings.AUTO_CREATE_APP_GROUP = True
+        app_group = AppGroup.objects.create(name='My group', slug='auth')
+        self.assertEqual(app_group.models.count(), 0)
+        request = self.factory.get(reverse('admin:index'))
+        request.user = self.superuser
+
+        result = AppGroup.objects.as_list(request, False)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(app_group.models.count(), 1)
+        settings.AUTO_CREATE_APP_GROUP = False
+
     def test_as_list_structure_compat_django18(self):
         request = self.factory.get(reverse('admin:index'))
         request.user = self.superuser


### PR DESCRIPTION
When an app_group was created with a certain slug ('test') and name ('Test')
and you tried to add another app_group with the slug ('test') and name ('Test2') it will throw an unique error. Because the name should not be used to fetch the app_group.