### PR TITLE
Add shadow and padding to .dropdown-menu__drop

### DIFF
--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -32,12 +32,14 @@
     }
 
     .dropdown-menu__drop {
+        box-shadow: 0 1px 1px 1px rgba(0, 0, 0, 0.4);
         position: absolute;
         left: 0;
         top: 100%;
         display: none;
         background-color: #417690;
         min-width: 150px;
+        padding: 0.2em;
     }
 
     .dropdown-menu__link,


### PR DESCRIPTION
I noticed a dropdown can has the same height as a link on the navigation bar. This creates a dropdown with a low contrast that creates the impression of an overflow issue (z-index).

I added a small padding to the dropdown creating a small offset to the navigation bar. I also added a small shadow to increase the contrast.