### PR TITLE
Issue/missing perms active menu item

### DIFF
--- a/django_admin_index/models.py
+++ b/django_admin_index/models.py
@@ -27,13 +27,23 @@ class AppGroupQuerySet(OrderedModelQuerySet):
                     app["app_label"], model["object_name"].lower()
                 )  # noqa
                 model_dict = model.copy()
+
+                # If the user lacks create/read/update permissions, these
+                # variables are None in the model_dict
+                if model_dict.get('admin_url'):
+                    active = request.path.startswith(model_dict['admin_url'])
+                elif model_dict.get('add_url'):
+                    active = request.path.startswith(model_dict['add_url'])
+                else:
+                    active = False
+
                 model_dict.update(
                     {
                         "app_label": app["app_label"],
                         "app_name": app["name"],
                         "app_url": app["app_url"],
                         "has_module_perms": app["has_module_perms"],
-                        "active": request.path.startswith(model_dict["admin_url"]),
+                        "active": active,
                     }
                 )
                 model_dicts[key] = model_dict

--- a/tests/unit/test_app_link.py
+++ b/tests/unit/test_app_link.py
@@ -153,3 +153,87 @@ class AdminIndexAppLinkTests(TestCase):
     #     context = dashboard(request)
     #     self.assertIn('dashboard_app_list', context)
     #     self.assertEqual(len(context['dashboard_app_list']), 1)
+
+    def test_dashboard_active_link_only_delete_permission(self):
+        self.app_link.link = "/admin/auth"
+        self.app_link.save()
+
+        user = self._create_user(username="test", is_staff=True)
+        permission = Permission.objects.get(name="Can delete user")
+        user.user_permissions.add(permission)
+
+        request = self.factory.get(reverse("admin:index"))
+        request.user = user
+
+        result = AppGroup.objects.as_list(request, False)
+
+        self.assertEqual(len(result), 1)
+
+        app = result[0]
+        app_model = app["models"][0]
+
+        self.assertEqual(
+            app_model,
+            {
+                "active": False,
+                "name": self.app_link.name,
+                "app_label": self.app_group.slug,
+                "admin_url": self.app_link.link,
+            },
+        )
+
+    def test_dashboard_active_link_only_add_permission(self):
+        self.app_link.link = "/admin/auth"
+        self.app_link.save()
+
+        user = self._create_user(username="test", is_staff=True)
+        permission = Permission.objects.get(name="Can add user")
+        user.user_permissions.add(permission)
+
+        request = self.factory.get(reverse("admin:auth_user_add"))
+        request.user = user
+
+        result = AppGroup.objects.as_list(request, False)
+
+        self.assertEqual(len(result), 1)
+
+        app = result[0]
+        app_model = app["models"][0]
+
+        self.assertEqual(
+            app_model,
+            {
+                "active": True,
+                "name": self.app_link.name,
+                "app_label": self.app_group.slug,
+                "admin_url": self.app_link.link,
+            },
+        )
+
+    def test_dashboard_active_link_only_change_permission(self):
+        self.app_link.link = "/admin/auth"
+        self.app_link.save()
+
+        user = self._create_user(username="test", is_staff=True)
+        permission = Permission.objects.get(name="Can change user")
+        user.user_permissions.add(permission)
+
+        request = self.factory.get(reverse("admin:auth_user_changelist"))
+        request.user = user
+
+        result = AppGroup.objects.as_list(request, False)
+
+        self.assertEqual(len(result), 1)
+
+        app = result[0]
+        app_model = app["models"][0]
+
+        self.assertEqual(
+            app_model,
+            {
+                "active": True,
+                "name": self.app_link.name,
+                "app_label": self.app_group.slug,
+                "admin_url": self.app_link.link,
+            },
+        )


### PR DESCRIPTION
Fixes issue with requests failing when determining the active menu item, if the user does not have change/view permissions on a model