### PR TITLE
Find appname using AppConfigs

### DIFF
--- a/django_admin_index/apps.py
+++ b/django_admin_index/apps.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.apps import AppConfig
+from django.apps import AppConfig, apps
 from django.core.checks import Tags, Warning, register
 from django.utils.translation import ugettext_lazy as _
 
@@ -23,11 +23,12 @@ def check_admin_index_app(app_configs, **kwargs):
     from django.conf import settings
 
     issues = []
+    app_config_names = [app_config.name for app_config in apps.get_app_configs()]
 
     try:
-        if settings.INSTALLED_APPS.index(
+        if app_config_names.index(
             AdminIndexConfig.name
-        ) > settings.INSTALLED_APPS.index("django.contrib.admin"):
+        ) > app_config_names.index("django.contrib.admin"):
             issues.append(
                 Warning(
                     "You should put '{}' before 'django.contrib.admin' in your INSTALLED_APPS.".format(

--- a/tests/proj/settings.py
+++ b/tests/proj/settings.py
@@ -35,6 +35,8 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     "django_admin_index",
+    "ordered_model",
+
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/tests/unit/test_admin_index.py
+++ b/tests/unit/test_admin_index.py
@@ -34,8 +34,18 @@ class AdminIndexTests(TestCase):
         result = check_admin_index_app([])
         self.assertEqual(len(result), 0)
 
+    @override_settings(INSTALLED_APPS=["django_admin_index", "django.contrib.admin.apps.AdminConfig"])
+    def test_check_admin_index_app_with_custom_admin_success(self):
+        result = check_admin_index_app([])
+        self.assertEqual(len(result), 0)
+
     @override_settings(INSTALLED_APPS=["django.contrib.admin", "django_admin_index"])
-    def test_check_admin_index_app_incorrect_order(self):
+    def test_check_admin_index_app_after_admin_app(self):
+        result = check_admin_index_app([])
+        self.assertEqual(len(result), 1)
+
+    @override_settings(INSTALLED_APPS=["django.contrib.admin.apps.AdminConfig", "django_admin_index"])
+    def test_check_admin_index_app_after_admin_app_with_custom_admin(self):
         result = check_admin_index_app([])
         self.assertEqual(len(result), 1)
 


### PR DESCRIPTION
Fixes #33 

When using AppConfigs in INSTALLED_APPS, the proper order of the INSTALLED_APPS could not be determined. This lead to am incorrect warning message.