### PR TITLE
Fixed calendar and time widgets `z-index`

### DIFF
--- a/scss/components/_containers.scss
+++ b/scss/components/_containers.scss
@@ -23,7 +23,7 @@ Override some containers to make the sticky header work with Django.
 
 // Fix the calendar and time widgets 
 .calendarbox, .clockbox {
-  z-index: 2;
+  z-index: 1;
 }
 
 #nav-sidebar {


### PR DESCRIPTION
As the containers have their z-index modified, we need to set the calendar and time widgets z-index to 2.