### PR TITLE
Applinks in admin as read_only

### DIFF
--- a/django_admin_index/models.py
+++ b/django_admin_index/models.py
@@ -86,6 +86,7 @@ class AppGroupQuerySet(OrderedModelQuerySet):
                         "app_label": app.slug,
                         "admin_url": app_link.link,
                         "active": request.path.startswith(app_link.link),
+                        "view_only": True,
                     }
                 )
                 active = request.path.startswith(app_link.link)

--- a/tests/unit/test_app_link.py
+++ b/tests/unit/test_app_link.py
@@ -59,6 +59,7 @@ class AdminIndexAppLinkTests(TestCase):
                 "name": self.app_link.name,
                 "app_label": self.app_group.slug,
                 "admin_url": self.app_link.link,
+                "view_only": True,
             },
         )
 
@@ -180,6 +181,7 @@ class AdminIndexAppLinkTests(TestCase):
                 "name": self.app_link.name,
                 "app_label": self.app_group.slug,
                 "admin_url": self.app_link.link,
+                "view_only": True,
             },
         )
 
@@ -208,6 +210,7 @@ class AdminIndexAppLinkTests(TestCase):
                 "name": self.app_link.name,
                 "app_label": self.app_group.slug,
                 "admin_url": self.app_link.link,
+                "view_only": True,
             },
         )
 
@@ -236,6 +239,7 @@ class AdminIndexAppLinkTests(TestCase):
                 "name": self.app_link.name,
                 "app_label": self.app_group.slug,
                 "admin_url": self.app_link.link,
+                "view_only": True,
             },
         )
 


### PR DESCRIPTION
Sets the view_only as True because from what I know these models aren't editable in the admin anyway. And this way they displayed more accurately in the index page of the admin.